### PR TITLE
wall time for systemd vscode app

### DIFF
--- a/specs/default/cluster-init/files/playbooks/files/applications/bc_vscode/form.yml.erb
+++ b/specs/default/cluster-init/files/playbooks/files/applications/bc_vscode/form.yml.erb
@@ -6,6 +6,8 @@ form:
   - num_gpus
   - working_dir
 attributes:
+  bc_num_hours:
+    display: true
   queue:
     widget: select
     options:

--- a/specs/default/cluster-init/files/playbooks/files/applications/systemd_vscode/form.yml.erb
+++ b/specs/default/cluster-init/files/playbooks/files/applications/systemd_vscode/form.yml.erb
@@ -1,8 +1,11 @@
 ---
 cluster: "login*"
 form:
+  - bc_num_hours
   - working_dir
 attributes:
+  bc_num_hours:
+    display: true
   working_dir:
     widget: "path_selector"
     label: "Working Directory"


### PR DESCRIPTION
add the bc_num_hours attribute to set the job wall_time for systemd vscode instances on login nodes