### PR TITLE
create a login cluster per login node instance

### DIFF
--- a/specs/default/cluster-init/files/playbooks/files/applications/systemd_vscode/manifest.yml
+++ b/specs/default/cluster-init/files/playbooks/files/applications/systemd_vscode/manifest.yml
@@ -4,7 +4,7 @@ category: Interactive Apps
 subcategory: Login Nodes
 role: batch_connect
 description: |
-  This app will launch a remote [VS Code] running as a web server.
+  This app will launch a remote [VS Code] running as a web server. In case of multiple login nodes they will be represented by a list under the "Cluster" list.
 
   [VS Code]: https://code.visualstudio.com"
 icon: fas://cog

--- a/specs/default/cluster-init/files/playbooks/roles/register_cluster/tasks/main.yml
+++ b/specs/default/cluster-init/files/playbooks/roles/register_cluster/tasks/main.yml
@@ -80,5 +80,6 @@
 - name: Create the login configuration file
   ansible.builtin.template:
     src: login_cluster.yml.j2
-    dest: "{{ ood_cluster_dir }}/login_slurm_{{ cluster_name }}.yml"
+    dest: "{{ ood_cluster_dir }}/login_{{ item }}.yml"
     mode: '0644'
+  loop: login_nodes

--- a/specs/default/cluster-init/files/playbooks/roles/register_cluster/templates/login_cluster.yml.j2
+++ b/specs/default/cluster-init/files/playbooks/roles/register_cluster/templates/login_cluster.yml.j2
@@ -1,16 +1,13 @@
 ---
 v2:
   metadata:
-    title: "Login {{cluster_name}}"
+    title: "Login {{ item }}"
     hidden: true
   job:
     adapter: "systemd"
-    # Submit host can be the IP of the LB in front of the login VMSS
-    submit_host: "{{ login_nodes | first }}"
+    submit_host: "{{ item }}"
     ssh_hosts:
-{% for node in login_nodes %}
-      - {{node}}
-{% endfor %}
+      - {{ item }}
 
     #site_timeout: 7200
     strict_host_checking: false


### PR DESCRIPTION
The systemd job adaptor cannot provide a way to select on which node you want to run. 
As a result the solution is to create one cluster defintion per login node instance which will be selectable in the application form.