### PR TITLE
fix: add conda ToS acceptance to prereqs_install.sh

### DIFF
--- a/specs/default/cluster-init/files/prereqs_install.sh
+++ b/specs/default/cluster-init/files/prereqs_install.sh
@@ -38,6 +38,7 @@ printf "Installing dependencies\n"
 ansible-playbook ${THIS_DIR}/dependencies.yml
 
 # Create oodconnector environment
+conda tos accept
 conda create --clone base --name oodconnector
 
 printf "\n\n"


### PR DESCRIPTION
Ensure Terms of Service for Anaconda channels are accepted before creating the oodconnector environment. This prevents CondaToSNonInteractiveError during Jetpack converge.

Error:
CondaToSNonInteractiveError: Terms of Service have not been accepted for the following channels. Please accept or remove them before proceeding:
    - https://repo.anaconda.com/pkgs/main
    - https://repo.anaconda.com/pkgs/r

To accept these channels' Terms of Service, run the following commands:
    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
