### PR TITLE
bump OOD Ansible version to v4.1.1 and remove repo URLs from vars files correctly set in the OOD Ansible repo

### DIFF
--- a/specs/default/cluster-init/files/install.sh
+++ b/specs/default/cluster-init/files/install.sh
@@ -3,7 +3,7 @@ TARGET=${1:-all}
 shift
 ANSIBLE_TAGS=$@
 set -e
-OOD_ANSIBLE_VERSION="v4.1.0"
+OOD_ANSIBLE_VERSION="v4.1.1"
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PLAYBOOKS_DIR=$THIS_DIR/playbooks
 

--- a/specs/default/cluster-init/files/playbooks/AlmaLinux/vars.yml
+++ b/specs/default/cluster-init/files/playbooks/AlmaLinux/vars.yml
@@ -2,8 +2,5 @@
 ood_package: "ondemand-{{ ondemand_version }}"
 ca_bundle_path: /etc/pki/tls/certs/ca-bundle.crt
 
-# Override repo URL to use OOD 4.1 repository - to be removed when upgrading to ood-ansible >4.0.1
-rpm_repo_url: "https://yum.osc.edu/ondemand/4.1/ondemand-release-web-4.1-1.{{ el_distro }}.noarch.rpm"
-
 # Install the ondemand-selinux package for proper SELinux policies
 install_ondemand_selinux: true

--- a/specs/default/cluster-init/files/playbooks/Ubuntu/vars.yml
+++ b/specs/default/cluster-init/files/playbooks/Ubuntu/vars.yml
@@ -1,6 +1,3 @@
 ---
 ood_package: "ondemand={{ ondemand_version }}"
 ca_bundle_path: /etc/ssl/certs/ca-certificates.crt
-
-# Override repo URL to use OOD 4.1 repository - to be removed when upgrading to ood-ansible >4.0.1
-apt_repo_url: "https://apt.osc.edu/ondemand/4.1/ondemand-release-web_4.1.0-{{ deb_distro }}_all.deb"


### PR DESCRIPTION
set the ood-ansible release to v4.1.1 which fix the default repo package URLs