### PR TITLE
Use system python

### DIFF
--- a/specs/default/cluster-init/files/install.sh
+++ b/specs/default/cluster-init/files/install.sh
@@ -10,7 +10,7 @@ PLAYBOOKS_DIR=$THIS_DIR/playbooks
 # Create or use the python venv oodenv environment
 PYTHON_ENV_DIR="${THIS_DIR}/oodenv"
 if [ ! -d "${PYTHON_ENV_DIR}" ]; then
-    python3 -m venv "${PYTHON_ENV_DIR}"
+    /usr/bin/python3 -m venv "${PYTHON_ENV_DIR}"
 fi
 # activate environment
 source "${PYTHON_ENV_DIR}/bin/activate"

--- a/specs/default/cluster-init/files/prereqs_install.sh
+++ b/specs/default/cluster-init/files/prereqs_install.sh
@@ -29,7 +29,7 @@ esac
 # Create or use the python venv oodenv environment
 PYTHON_ENV_DIR="${THIS_DIR}/oodenv"
 if [ ! -d "${PYTHON_ENV_DIR}" ]; then
-    python3 -m venv "${PYTHON_ENV_DIR}"
+    /usr/bin/python3 -m venv "${PYTHON_ENV_DIR}"
 fi
 # activate environment
 source "${PYTHON_ENV_DIR}/bin/activate"


### PR DESCRIPTION
Avoid silent use of jetpack embedded python to get expected results. Older jetpack embedded python can lead to older pip being installed and selecting source distributions of dependency packages which then fail to compile.

Admittedly, this was found with quite an old version of Cyclecloud (8.6, embedded python 3.8). But explicit system prereq package installation seems to suggest that OS python usage is expected nonetheless, enabling support of old Cyclecloud versions in this case.