### PR TITLE
Remove use of curls in playbooks; use API instead

### DIFF
--- a/specs/default/cluster-init/files/playbooks/register_cluster.yml
+++ b/specs/default/cluster-init/files/playbooks/register_cluster.yml
@@ -34,12 +34,13 @@
       url_username: "{{ cyclecloud_username.stdout }}"
       url_password: "{{ cyclecloud_password.stdout }}"
     register: api_response_cluster_list
+    no_log: true
 
   - name: Export API results to JSON File
     ansible.builtin.copy:
       content: "{{ api_response_cluster_list.json | to_nice_json }}"
       dest: "/tmp/raw_clusters.json"
-      mode: '0644'
+      mode: '0600'
 
   - name: Get raw list of clusters
     shell: |
@@ -72,13 +73,14 @@
     with_items: "{{ clusters }}"
     when: clusters | length > 0
     register: api_response_nodes_by_cluster
+    no_log: true
 
   - name: Save node status per cluster
     ansible.builtin.copy:
       content: "{{ item.json | to_nice_json }}"
       dest: "/tmp/{{ item.item.name }}_nodes_raw.json"
-      mode: '0644'
-    loop: "{{ api_response_nodes_by_cluster.results }}"
+      mode: '0600'
+    loop: "{{ api_response_nodes_by_cluster.results if (api_response_nodes_by_cluster is defined and api_response_nodes_by_cluster.results is defined) else [] }}"
     when: item.skipped is not defined or not item.skipped
 
   - name: Get node arrays per cluster

--- a/specs/default/cluster-init/files/playbooks/register_cluster.yml
+++ b/specs/default/cluster-init/files/playbooks/register_cluster.yml
@@ -23,9 +23,26 @@
       jetpack config cyclecloud.config.web_server
     register: cyclecloud_url
 
+  - name: API call for list of clusters
+    uri:
+      url: "{{ cyclecloud_url.stdout }}/cloud/clusters"
+      method: GET
+      return_content: yes
+      status_code: 200
+      validate_certs: false
+      force_basic_auth: true
+      url_username: "{{ cyclecloud_username.stdout }}"
+      url_password: "{{ cyclecloud_password.stdout }}"
+    register: api_response_cluster_list
+
+  - name: Export API results to JSON File
+    ansible.builtin.copy:
+      content: "{{ api_response_cluster_list.json | to_nice_json }}"
+      dest: "/tmp/raw_clusters.json"
+      mode: '0644'
+
   - name: Get raw list of clusters
     shell: |
-      curl -k -u {{ cyclecloud_username.stdout }}:{{ cyclecloud_password.stdout }} {{ cyclecloud_url.stdout }}/cloud/clusters > /tmp/raw_clusters.json
       # Select only started schedulers based clusters
       jq '[.[] | select(.Category == "Schedulers" and .State == "Started")]' /tmp/raw_clusters.json > /tmp/active_clusters.json
       # for each active clusters with no BaseName, if "slurm" is present in any properties, set BaseName to "slurm"
@@ -42,10 +59,32 @@
     set_fact:
       clusters: "{{ clusters_raw.stdout | from_yaml }}"
 
-  - name: get node arrays per cluster
-    shell: |
-      curl -k -u {{ cyclecloud_username.stdout }}:{{ cyclecloud_password.stdout }} {{ cyclecloud_url.stdout }}/clusters/{{item.name}}/status?nodes | jq '[.nodearrays[] | select(.buckets[0].quotaCount > 0 and .nodearray.Extends == "nodearraybase") | {name: .name, machineType: .buckets[0].definition.machineType, vcpuCount: .buckets[0].virtualMachine.vcpuCount, gpuCount: .buckets[0].virtualMachine.gpuCount, memorySizeGB: .buckets[0].virtualMachine.memory, infiniband: .buckets[0].virtualMachine.infiniband}]' > /tmp/{{ item.name }}.nodearrays.json
+  - name: API call for nodes by cluster
+    uri:
+      url: "{{ cyclecloud_url.stdout }}/clusters/{{item.name}}/status?nodes"
+      method: GET
+      return_content: yes
+      status_code: 200
+      validate_certs: false
+      force_basic_auth: true
+      url_username: "{{ cyclecloud_username.stdout }}"
+      url_password: "{{ cyclecloud_password.stdout }}"
     with_items: "{{ clusters }}"
+    when: clusters | length > 0
+    register: api_response_nodes_by_cluster
+
+  - name: Save node status per cluster
+    ansible.builtin.copy:
+      content: "{{ item.json | to_nice_json }}"
+      dest: "/tmp/{{ item.item.name }}_nodes_raw.json"
+      mode: '0644'
+    loop: "{{ api_response_nodes_by_cluster.results }}"
+    when: item.skipped is not defined or not item.skipped
+
+  - name: Get node arrays per cluster
+    shell: |
+      jq '[.nodearrays[] | select(.buckets[0].quotaCount > 0 and .nodearray.Extends == "nodearraybase") | {name: .name, machineType: .buckets[0].definition.machineType, vcpuCount: .buckets[0].virtualMachine.vcpuCount, gpuCount: .buckets[0].virtualMachine.gpuCount, memorySizeGB: .buckets[0].virtualMachine.memory, infiniband: .buckets[0].virtualMachine.infiniband}]' /tmp/{{ item.name }}_nodes_raw.json > /tmp/{{ item.name }}.nodearrays.json
+    loop: "{{ clusters }}"
     when: clusters | length > 0
 
   - name: merge node arrays into clusters

--- a/specs/default/cluster-init/files/playbooks/register_cluster.yml
+++ b/specs/default/cluster-init/files/playbooks/register_cluster.yml
@@ -36,24 +36,30 @@
     register: api_response_cluster_list
     no_log: true
 
+  - name: Create temporary directory
+    ansible.builtin.file:
+      path: "/tmp/playbook_files"
+      state: directory
+      mode: '0700'
+
   - name: Export API results to JSON File
     ansible.builtin.copy:
       content: "{{ api_response_cluster_list.json | to_nice_json }}"
-      dest: "/tmp/raw_clusters.json"
+      dest: "/tmp/playbook_files/raw_clusters.json"
       mode: '0600'
 
   - name: Get raw list of clusters
     shell: |
       # Select only started schedulers based clusters
-      jq '[.[] | select(.Category == "Schedulers" and .State == "Started")]' /tmp/raw_clusters.json > /tmp/active_clusters.json
+      jq '[.[] | select(.Category == "Schedulers" and .State == "Started")]' /tmp/playbook_files/raw_clusters.json > /tmp/playbook_files/active_clusters.json
       # for each active clusters with no BaseName, if "slurm" is present in any properties, set BaseName to "slurm"
-      jq 'map(if (has("BaseName") | not) and (tostring | ascii_downcase | contains("slurm")) then . + {BaseName: "slurm"} else . end)' /tmp/active_clusters.json > /tmp/active_clusters_temp.json           
-      mv /tmp/active_clusters_temp.json /tmp/active_clusters.json
+      jq 'map(if (has("BaseName") | not) and (tostring | ascii_downcase | contains("slurm")) then . + {BaseName: "slurm"} else . end)' /tmp/playbook_files/active_clusters.json > /tmp/playbook_files/active_clusters_temp.json           
+      mv /tmp/playbook_files/active_clusters_temp.json /tmp/playbook_files/active_clusters.json
     
   - name: Get active clusters
     shell: |
-      jq -r '[.[]  | select(.State=="Started" and .BaseName!=null) | {name: .ClusterName, scheduler: .BaseName}]' /tmp/active_clusters.json > /tmp/clusters.json
-      yq -P /tmp/clusters.json
+      jq -r '[.[]  | select(.State=="Started" and .BaseName!=null) | {name: .ClusterName, scheduler: .BaseName}]' /tmp/playbook_files/active_clusters.json > /tmp/playbook_files/clusters.json
+      yq -P /tmp/playbook_files/clusters.json
     register: clusters_raw
 
   - name: Set fact with active cluster list
@@ -78,21 +84,21 @@
   - name: Save node status per cluster
     ansible.builtin.copy:
       content: "{{ item.json | to_nice_json }}"
-      dest: "/tmp/{{ item.item.name }}_nodes_raw.json"
+      dest: "/tmp/playbook_files/{{ item.item.name }}_nodes_raw.json"
       mode: '0600'
     loop: "{{ api_response_nodes_by_cluster.results if (api_response_nodes_by_cluster is defined and api_response_nodes_by_cluster.results is defined) else [] }}"
     when: item.skipped is not defined or not item.skipped
 
   - name: Get node arrays per cluster
     shell: |
-      jq '[.nodearrays[] | select(.buckets[0].quotaCount > 0 and .nodearray.Extends == "nodearraybase") | {name: .name, machineType: .buckets[0].definition.machineType, vcpuCount: .buckets[0].virtualMachine.vcpuCount, gpuCount: .buckets[0].virtualMachine.gpuCount, memorySizeGB: .buckets[0].virtualMachine.memory, infiniband: .buckets[0].virtualMachine.infiniband}]' /tmp/{{ item.name }}_nodes_raw.json > /tmp/{{ item.name }}.nodearrays.json
+      jq '[.nodearrays[] | select(.buckets[0].quotaCount > 0 and .nodearray.Extends == "nodearraybase") | {name: .name, machineType: .buckets[0].definition.machineType, vcpuCount: .buckets[0].virtualMachine.vcpuCount, gpuCount: .buckets[0].virtualMachine.gpuCount, memorySizeGB: .buckets[0].virtualMachine.memory, infiniband: .buckets[0].virtualMachine.infiniband}]' /tmp/playbook_files/{{ item.name }}_nodes_raw.json > /tmp/playbook_files/{{ item.name }}.nodearrays.json
     loop: "{{ clusters }}"
     when: clusters | length > 0
 
   - name: merge node arrays into clusters
     shell: |
-      jq -c '.[]' /tmp/clusters.json | while read -r obj; do
-        file="/tmp/$(echo "$obj" | jq -r '.name').nodearrays.json"
+      jq -c '.[]' /tmp/playbook_files/clusters.json | while read -r obj; do
+        file="/tmp/playbook_files/$(echo "$obj" | jq -r '.name').nodearrays.json"
         extra=$(jq '.' "$file")
         echo "$obj" | jq --argjson extra "$extra" '.queues += $extra'
       done | jq -s '.' | yq e -P
@@ -139,7 +145,7 @@
 
   - name: Gather active login nodes of active clusters by cluster
     shell: |
-      jq -r '.nodes[] | select(.Status=="Ready") | select(.Template=="login") | .Hostname' /tmp/{{ item.name }}.json
+      jq -r '.nodes[] | select(.Status=="Ready") | select(.Template=="login") | .Hostname' /tmp/playbook_files/{{ item.name }}.json
     with_items: "{{ clusters }}"
     register: login_nodes_by_cluster
     changed_when: false
@@ -165,3 +171,8 @@
       state: absent
     loop: "{{ deleted_login_nodes }}"
     when: deleted_login_nodes | length > 0
+
+  - name: Clean up temporary files
+    ansible.builtin.file:
+      path: /tmp/playbook_files
+      state: absent

--- a/specs/default/cluster-init/files/playbooks/roles/register_cluster/tasks/main.yml
+++ b/specs/default/cluster-init/files/playbooks/roles/register_cluster/tasks/main.yml
@@ -18,9 +18,23 @@
   set_fact:
     bin_overrides_dir: "{{ood_cluster_dir}}/slurm_{{ cluster_name }}/bin_overrides"
 
-- name: Retrieve the node list
-  shell: |
-    curl -k -u {{ cyclecloud_username.stdout }}:{{ cyclecloud_password.stdout }} {{ cyclecloud_url.stdout }}/clusters/{{ cluster_name }}/nodes > /tmp/{{ cluster_name }}.json
+- name: API call for list of nodes
+  uri:
+    url: "{{ cyclecloud_url.stdout }}/clusters/{{ cluster_name }}/nodes"
+    method: GET
+    return_content: yes
+    status_code: 200
+    validate_certs: false
+    force_basic_auth: true
+    url_username: "{{ cyclecloud_username.stdout }}"
+    url_password: "{{ cyclecloud_password.stdout }}"
+  register: api_response_node_list
+
+- name: Export API Results to JSON File
+  ansible.builtin.copy:
+    content: "{{ api_response_node_list.json | to_nice_json }}"
+    dest: "/tmp/{{ cluster_name }}.json"
+    mode: '0644'
   
 - name: Retrieve the login nodes
   shell: |

--- a/specs/default/cluster-init/files/playbooks/roles/register_cluster/tasks/main.yml
+++ b/specs/default/cluster-init/files/playbooks/roles/register_cluster/tasks/main.yml
@@ -34,12 +34,12 @@
 - name: Export API Results to JSON File
   ansible.builtin.copy:
     content: "{{ api_response_node_list.json | to_nice_json }}"
-    dest: "/tmp/{{ cluster_name }}.json"
+    dest: "/tmp/playbook_files/{{ cluster_name }}.json"
     mode: '0600'
   
 - name: Retrieve the login nodes
   shell: |
-    jq -r '.nodes[] | select(.Status=="Ready") | select(.Template=="login") | .Hostname' /tmp/{{ cluster_name }}.json
+    jq -r '.nodes[] | select(.Status=="Ready") | select(.Template=="login") | .Hostname' /tmp/playbook_files/{{ cluster_name }}.json
   register: login_nodes
 
 - name: set the node list array
@@ -57,7 +57,7 @@
 
 - name: Retrieve the scheduler node
   shell: |
-    jq -r '.nodes[] | select(.Status=="Ready") | select(.Template=="scheduler") | .Hostname' /tmp/{{ cluster_name }}.json
+    jq -r '.nodes[] | select(.Status=="Ready") | select(.Template=="scheduler") | .Hostname' /tmp/playbook_files/{{ cluster_name }}.json
   register: scheduler
 
 - name: set the scheduler name

--- a/specs/default/cluster-init/files/playbooks/roles/register_cluster/tasks/main.yml
+++ b/specs/default/cluster-init/files/playbooks/roles/register_cluster/tasks/main.yml
@@ -29,12 +29,13 @@
     url_username: "{{ cyclecloud_username.stdout }}"
     url_password: "{{ cyclecloud_password.stdout }}"
   register: api_response_node_list
+  no_log: true
 
 - name: Export API Results to JSON File
   ansible.builtin.copy:
     content: "{{ api_response_node_list.json | to_nice_json }}"
     dest: "/tmp/{{ cluster_name }}.json"
-    mode: '0644'
+    mode: '0600'
   
 - name: Retrieve the login nodes
   shell: |


### PR DESCRIPTION
Motivation: Low-level auth users can see cyclecloud_access username and password in /proc when curls are used to gather cluster info.